### PR TITLE
Update github.com/thepwagner/action-update from v0.0.7 to v0.0.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/moby/buildkit v0.7.2
 	github.com/stretchr/testify v1.6.1
-	github.com/thepwagner/action-update v0.0.7
+	github.com/thepwagner/action-update v0.0.8
 	golang.org/x/mod v0.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
-github.com/dependabot/gomodules-extracted v1.1.0 h1:k0Fcin3JZBfd/yW0JEeg38UtTiZl6E9uYkdqA4Dqbyw=
-github.com/dependabot/gomodules-extracted v1.1.0/go.mod h1:+dRXSrUymjpT4yzKtn1QmeknT1S/yAHRr35en18dHp8=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20200227165822-2298e6a3fe24/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
@@ -253,8 +251,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/thepwagner/action-update v0.0.7 h1:9NsXwDaT7ZQiXKEpp+caixVIWitFeL00ARJ2BYrQ49s=
-github.com/thepwagner/action-update v0.0.7/go.mod h1:jqyo3EX+GsD47MjWU6s98s/8iQ08IEp9MbvkGJM+txw=
+github.com/thepwagner/action-update v0.0.8 h1:PrnqiespyGWr8slA3EOk+FBgYzKziuki24mPJXCSm60=
+github.com/thepwagner/action-update v0.0.8/go.mod h1:VrGP6NoWBhpwicDG4nqiw9XlkuwmrjLb1FaJQTbLi1I=
 github.com/tonistiigi/fsutil v0.0.0-20200326231323-c2c7d7b0e144/go.mod h1:0G1sLZ/0ttFf09xvh7GR4AEECnjifHRNJN/sYbLianU=
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea/go.mod h1:WPnis/6cRcDZSUvVmezrxJPkiO87ThFYsoUiMwWNDJk=
 github.com/uber/jaeger-client-go v0.0.0-20180103221425-e02c85f9069e/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=


### PR DESCRIPTION
Here is github.com/thepwagner/action-update v0.0.8, I hope it works.

<!--::action-update-go::
{"updates":[{"path":"github.com/thepwagner/action-update","previous":"v0.0.7","next":"v0.0.8"}],"signature":"/I1B4XZ6iC600ussGfppx/wamAT96RtjDKJyS/0ouMnDBmxH67qQVJASTxG4yYE2HuWbCIHSoEqQQvvUYzCNbg=="}
-->