### PR TITLE
Update golang from 1.15.1 to 1.15.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15.0'
+        go-version: '1.15.3'
     - run: script/test
     - run: script/lint

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.MY_GITHUB_PAT }}
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.0'
+          go-version: '1.15.3'
       - uses: thepwagner/action-update-go@main
         with:
           log_level: debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.1 AS builder
+FROM golang:1.15.3 AS builder
 
 WORKDIR /app
 COPY go.mod /app


### PR DESCRIPTION
Here is golang 1.15.3, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golang","previous":"1.15.1","next":"1.15.3"}]},"signature":"6Uq5YqGAYBRYNdYFPTa3LQdwUBQ+GiLsruyaYsB40crgjb77gmGI0BnmfTp7HBnnnSOnX9lvV0PX4FnSFh5DYA=="}
-->