### PR TITLE
Update golangci/golangci-lint from v1.31.0-alpine to v1.32.0-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.31.0-alpine
+FROM golangci/golangci-lint:v1.32.0-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.32.0-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golangci/golangci-lint","previous":"v1.31.0-alpine","next":"v1.32.0-alpine"}]},"signature":"OcxQ+6Z5aLSMFgmxHsdgKy2x4jllblm+IgWYyYH/c/br1e5MWEzbvIh0M+3q+ZR1iUZh4lRYJ09DMfrw0trr/A=="}
-->