### PR TITLE
Update github.com/thepwagner/action-update from  to v0.0.28

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/viper v1.7.1 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/thepwagner/action-update v0.0.27
+	github.com/thepwagner/action-update v0.0.28
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	golang.org/x/mod v0.3.0
 	gopkg.in/dancannon/gorethink.v3 v3.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -967,8 +967,8 @@ github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tetafro/godot v0.3.7/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/tetafro/godot v0.4.2/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
-github.com/thepwagner/action-update v0.0.27 h1:5wZCtYJU6jLX1ypTIXtTc3l0QH8QJM3QqQlYHnBvkFs=
-github.com/thepwagner/action-update v0.0.27/go.mod h1:fYlNdEIgTv2uZf0n4Dk5+p17v7bjxYhw07lHR2ENXTw=
+github.com/thepwagner/action-update v0.0.28 h1:503klKa9TbArCObpzZwkD9DV+FjW0u0dOU+VuK6LmEc=
+github.com/thepwagner/action-update v0.0.28/go.mod h1:fYlNdEIgTv2uZf0n4Dk5+p17v7bjxYhw07lHR2ENXTw=
 github.com/theupdateframework/notary v0.6.1 h1:7wshjstgS9x9F5LuB1L5mBI2xNMObWqjz+cjWoom6l0=
 github.com/theupdateframework/notary v0.6.1/go.mod h1:MOfgIfmox8s7/7fduvB2xyPPMJCrjRLRizA8OFwpnKY=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=

--- a/vendor/github.com/thepwagner/action-update/actions/handlers.go
+++ b/vendor/github.com/thepwagner/action-update/actions/handlers.go
@@ -99,11 +99,11 @@ func (h *Handlers) handler(event string) func(context.Context, interface{}) erro
 		}
 
 	case "workflow_dispatch":
-		if h.Schedule == nil {
+		if h.WorkflowDispatch == nil {
 			return nil
 		}
 		return func(ctx context.Context, _ interface{}) error {
-			return h.Schedule(ctx)
+			return h.WorkflowDispatch(ctx)
 		}
 
 	default:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -277,7 +277,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thepwagner/action-update v0.0.27
+# github.com/thepwagner/action-update v0.0.28
 ## explicit
 github.com/thepwagner/action-update/actions
 github.com/thepwagner/action-update/actions/updateaction


### PR DESCRIPTION
Here is github.com/thepwagner/action-update v0.0.28, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/thepwagner/action-update","previous":"","next":"v0.0.28"}]},"signature":"Hso+a/OlZB1e3KXRGVbzGu/x40FPjIB+ONytAbQ6V8cwh0b6oaImW4fRdzBpAo24GkAlgX9WjL/GpMfMXuzADg=="}
-->