### PR TITLE
Update golang.org/x/mod from v0.3.0 to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/thepwagner/action-update v0.0.28
 	github.com/theupdateframework/notary v0.6.1 // indirect
-	golang.org/x/mod v0.3.0
+	golang.org/x/mod v0.4.0
 	gopkg.in/dancannon/gorethink.v3 v3.0.5 // indirect
 	gopkg.in/fatih/pool.v2 v2.0.0 // indirect
 	gopkg.in/gorethink/gorethink.v3 v3.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1116,6 +1116,8 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
+golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/vendor/golang.org/x/mod/semver/semver.go
+++ b/vendor/golang.org/x/mod/semver/semver.go
@@ -138,6 +138,9 @@ func Compare(v, w string) int {
 
 // Max canonicalizes its arguments and then returns the version string
 // that compares greater.
+//
+// Deprecated: use Compare instead. In most cases, returning a canonicalized
+// version is not expected or desired.
 func Max(v, w string) string {
 	v = Canonical(v)
 	w = Canonical(w)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -324,7 +324,7 @@ golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/knownhosts
 golang.org/x/crypto/ssh/terminal
-# golang.org/x/mod v0.3.0
+# golang.org/x/mod v0.4.0
 ## explicit
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20201010224723-4f7140c49acb


### PR DESCRIPTION
Here is golang.org/x/mod v0.4.0, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golang.org/x/mod","previous":"v0.3.0","next":"v0.4.0"}]},"signature":"/tvBXiKHfctBQda0QPKLxeieKmgP+jW2tZxxpnHT2AZhDWId3kJQukREopgQLVM0Qc5cT/VmScql6PWd4VcTkA=="}
-->