### PR TITLE
Update golang.org/x/mod from v0.4.1 to v0.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/thepwagner/action-update v0.0.38
 	github.com/theupdateframework/notary v0.7.0 // indirect
-	golang.org/x/mod v0.4.1
+	golang.org/x/mod v0.4.2
 
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1106,8 +1106,9 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -312,7 +312,7 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/knownhosts
-# golang.org/x/mod v0.4.1
+# golang.org/x/mod v0.4.2
 ## explicit
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20201010224723-4f7140c49acb


### PR DESCRIPTION
Here is golang.org/x/mod v0.4.2, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golang.org/x/mod","previous":"v0.4.1","next":"v0.4.2"}]},"signature":"VsoNaebibWE7xq0vxm7+EqN5YiZ+g5K8guj5HNBRHpIs5zVsJKDU56Uhqp/6cAo52rSua2NWq4wj0s/BW/IEUg=="}
-->