### PR TITLE
Update github.com/moby/buildkit from v0.8.2 to v0.8.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/lib/pq v1.10.1 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
 	github.com/miekg/pkcs11 v1.0.3 // indirect
-	github.com/moby/buildkit v0.8.2
+	github.com/moby/buildkit v0.8.3
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.7.1 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -724,8 +724,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.3.1 h1:cCBH2gTD2K0OtLlv/Y5H01VQCqmlDxz30kS5Y5bqfLA=
 github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
-github.com/moby/buildkit v0.8.2 h1:kvb0cLWss4mOhCxcXSTENzzA+t1JR1eIyXFhDrI+73g=
-github.com/moby/buildkit v0.8.2/go.mod h1:5PZi7ALzuxG604ggYSeN+rzC+CyJscuXS7WetulJr1Y=
+github.com/moby/buildkit v0.8.3 h1:vFlwUQ6BZE1loZ8zoZH3fYgmA1djFCS3DrOhCVU6ZZE=
+github.com/moby/buildkit v0.8.3/go.mod h1:jUezwyOvKdkbcvR66WuKzPYQUO3sQ8i/eChLZ7kEmg8=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/moby v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible h1:zTnM9zBtyWn5qBGVVhhbGYIWVsYtiuEZPHSctpjbrGg=
 github.com/moby/moby v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -211,7 +211,7 @@ github.com/matttproud/golang_protobuf_extensions/pbutil
 github.com/miekg/pkcs11
 # github.com/mitchellh/go-homedir v1.1.0
 github.com/mitchellh/go-homedir
-# github.com/moby/buildkit v0.8.2
+# github.com/moby/buildkit v0.8.3
 ## explicit
 github.com/moby/buildkit/frontend/dockerfile/command
 github.com/moby/buildkit/frontend/dockerfile/parser


### PR DESCRIPTION
Here is github.com/moby/buildkit v0.8.3, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/moby/buildkit","previous":"v0.8.2","next":"v0.8.3"}]},"signature":"/tsUCnMqwsxnKs6Macl4debd3teG2Zcd9qGf6FyIXvRCspqRDBDycHRXcwnfyXkm8VXA3FC6SX8iTVrssCctUg=="}
-->