### PR TITLE
Update golang from 1.16.3 to 1.16.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,6 @@ jobs:
           ${{ runner.os }}-go-
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.16.3'
+        go-version: '1.16.4'
     - run: script/test
     - run: script/lint

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -22,7 +22,7 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.4'
       - uses: thepwagner/action-update-go@main
         with:
           log_level: debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3 AS builder
+FROM golang:1.16.4 AS builder
 
 WORKDIR /app
 COPY go.mod /app


### PR DESCRIPTION
Here is golang 1.16.4, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golang","previous":"1.16.3","next":"1.16.4"}]},"signature":"4ZYIUTymf20X8mEKXUajbm/LoKTvDMdua+7egpjVKR6z/g2mVSuRtfI5Hc7QXvuA851NaVqAl9waQqKpy/Ztvg=="}
-->