### PR TITLE
Update golang from 1.16.4 to 1.16.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,6 @@ jobs:
           ${{ runner.os }}-go-
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.16.4'
+        go-version: '1.16.5'
     - run: script/test
     - run: script/lint

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -22,7 +22,7 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.5'
       - uses: thepwagner/action-update-go@main
         with:
           log_level: debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4 AS builder
+FROM golang:1.16.5 AS builder
 
 WORKDIR /app
 COPY go.mod /app


### PR DESCRIPTION
Here is golang 1.16.5, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golang","previous":"1.16.4","next":"1.16.5"}]},"signature":"EsJDrVaMV8nzAbDR1pFxzFhRdrx28OXt7xAkKNOqWUVX1Bx6Zx+8wR/vM6GcX9JSCMsxcwFkoOvHhe5dHe/dCA=="}
-->