### PR TITLE
Update github.com/docker/cli from v20.10.7+incompatible to v20.10.8+incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/cloudflare/cfssl v1.6.0 // indirect
-	github.com/docker/cli v20.10.7+incompatible
+	github.com/docker/cli v20.10.8+incompatible
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/fvbommel/sortorder v1.0.2 // indirect
 	github.com/jinzhu/gorm v1.9.16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,9 @@ github.com/docker/cli v0.0.0-20190925022749-754388324470/go.mod h1:JLrzqnKDaYBop
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.0-beta1.0.20201029214301-1d20b15adc38+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.6+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/cli v20.10.7+incompatible h1:pv/3NqibQKphWZiAskMzdz8w0PRbtTaEB+f6NwdU7Is=
 github.com/docker/cli v20.10.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v20.10.8+incompatible h1:/zO/6y9IOpcehE49yMRTV9ea0nBpb8OeqSskXLNfH1E=
+github.com/docker/cli v20.10.8+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.6.0-rc.1.0.20180327202408-83389a148052+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=

--- a/vendor/github.com/docker/cli/cli/command/cli.go
+++ b/vendor/github.com/docker/cli/cli/command/cli.go
@@ -255,7 +255,7 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...Initialize
 		if tlsconfig.IsErrEncryptedKey(err) {
 			passRetriever := passphrase.PromptRetrieverWithInOut(cli.In(), cli.Out(), nil)
 			newClient := func(password string) (client.APIClient, error) {
-				cli.dockerEndpoint.TLSPassword = password
+				cli.dockerEndpoint.TLSPassword = password //nolint: staticcheck // SA1019: cli.dockerEndpoint.TLSPassword is deprecated
 				return newAPIClientFromEndpoint(cli.dockerEndpoint, cli.configFile)
 			}
 			cli.client, err = getClientWithPassword(passRetriever, newClient)

--- a/vendor/github.com/docker/cli/cli/connhelper/connhelper.go
+++ b/vendor/github.com/docker/cli/cli/connhelper/connhelper.go
@@ -49,7 +49,7 @@ func getConnectionHelper(daemonURL string, sshFlags []string) (*ConnectionHelper
 			Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				return commandconn.New(ctx, "ssh", append(sshFlags, sp.Args("docker", "system", "dial-stdio")...)...)
 			},
-			Host: "http://docker",
+			Host: "http://docker.example.com",
 		}, nil
 	}
 	// Future version may support plugins via ~/.docker/config.json. e.g. "dind"
@@ -63,6 +63,6 @@ func GetCommandConnectionHelper(cmd string, flags ...string) (*ConnectionHelper,
 		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return commandconn.New(ctx, cmd, flags...)
 		},
-		Host: "http://docker",
+		Host: "http://docker.example.com",
 	}, nil
 }

--- a/vendor/github.com/docker/cli/cli/context/docker/load.go
+++ b/vendor/github.com/docker/cli/cli/context/docker/load.go
@@ -26,7 +26,12 @@ type EndpointMeta = context.EndpointMetaBase
 // a Docker Engine endpoint, with its tls data
 type Endpoint struct {
 	EndpointMeta
-	TLSData     *context.TLSData
+	TLSData *context.TLSData
+
+	// Deprecated: Use of encrypted TLS private keys has been deprecated, and
+	// will be removed in a future release. Golang has deprecated support for
+	// legacy PEM encryption (as specified in RFC 1423), as it is insecure by
+	// design (see https://go-review.googlesource.com/c/go/+/264159).
 	TLSPassword string
 }
 
@@ -66,8 +71,9 @@ func (c *Endpoint) tlsConfig() (*tls.Config, error) {
 		}
 
 		var err error
-		if x509.IsEncryptedPEMBlock(pemBlock) {
-			keyBytes, err = x509.DecryptPEMBlock(pemBlock, []byte(c.TLSPassword))
+		// TODO should we follow Golang, and deprecate RFC 1423 encryption, and produce a warning (or just error)? see https://github.com/docker/cli/issues/3212
+		if x509.IsEncryptedPEMBlock(pemBlock) { //nolint: staticcheck // SA1019: x509.IsEncryptedPEMBlock is deprecated, and insecure by design
+			keyBytes, err = x509.DecryptPEMBlock(pemBlock, []byte(c.TLSPassword)) //nolint: staticcheck // SA1019: x509.IsEncryptedPEMBlock is deprecated, and insecure by design
 			if err != nil {
 				return nil, errors.Wrap(err, "private key is encrypted, but could not decrypt it")
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -43,7 +43,7 @@ github.com/containerd/continuity/pathdriver
 github.com/containerd/typeurl
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/docker/cli v20.10.7+incompatible
+# github.com/docker/cli v20.10.8+incompatible
 ## explicit
 github.com/docker/cli/cli/command
 github.com/docker/cli/cli/config


### PR DESCRIPTION
Here is github.com/docker/cli v20.10.8+incompatible, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/docker/cli","previous":"v20.10.7+incompatible","next":"v20.10.8+incompatible"}]},"signature":"TzAJibopvPyfdU8jcpXjyqLSrdsTpj8VQ6DH9FhXquOkpV1MHkLnqd2qCfWiskmdr+uiD6Xj7JGnJ38gqoe5MA=="}
-->